### PR TITLE
use log/slog and export client state

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"os"
 	"os/signal"
+	"time"
 )
 
 func main() {
@@ -37,7 +38,9 @@ func main() {
 		pkt := msg.(*pb.MeshPacket)
 		log.Info("Received message from radio", "msg", pkt)
 	})
-	if client.Connect() != nil {
+	ctxTimeout, cancelTimeout := context.WithTimeout(ctx, 10*time.Second)
+	defer cancelTimeout()
+	if client.Connect(ctxTimeout) != nil {
 		panic("Failed to connect to the radio")
 	}
 

--- a/transport/client.go
+++ b/transport/client.go
@@ -249,7 +249,7 @@ func (c *Client) Connect(ctx context.Context) error {
 		case <-ctx.Done():
 			return ErrTimeout
 		case <-ticker.C:
-			done := c.State.complete
+			done := c.State.Complete()
 			if done {
 				return nil
 			}

--- a/transport/client.go
+++ b/transport/client.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"math/rand"
 	"sync"
-	"time"
 )
 
 var (
@@ -262,8 +261,6 @@ func (c *Client) Connect(ctx context.Context) error {
 			}
 		}
 	}()
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
 
 	for {
 		select {

--- a/transport/client.go
+++ b/transport/client.go
@@ -128,7 +128,7 @@ func (s *State) AddConfig(config *meshtastic.Config) {
 	s.configs = append(s.configs, config)
 }
 
-func (s *State) AddModules(module *meshtastic.ModuleConfig) {
+func (s *State) AddModule(module *meshtastic.ModuleConfig) {
 	s.Lock()
 	defer s.Unlock()
 	s.modules = append(s.modules, module)
@@ -203,7 +203,7 @@ func (c *Client) Connect(ctx context.Context) error {
 				variant = cfg
 			case *meshtastic.FromRadio_ModuleConfig:
 				cfg := msg.GetModuleConfig()
-				c.State.AddModules(cfg)
+				c.State.AddModule(cfg)
 				variant = cfg
 			case *meshtastic.FromRadio_ConfigCompleteId:
 				// logged here because it's not an actual proto.Message that we can call handlers on

--- a/transport/client.go
+++ b/transport/client.go
@@ -59,31 +59,47 @@ func (s *State) NodeInfo() *meshtastic.MyNodeInfo {
 func (s *State) DeviceMetadata() *meshtastic.DeviceMetadata {
 	s.RLock()
 	defer s.RUnlock()
-	return s.deviceMetadata
+	return proto.Clone(s.deviceMetadata).(*meshtastic.DeviceMetadata)
 }
 
 func (s *State) Nodes() []*meshtastic.NodeInfo {
 	s.RLock()
 	defer s.RUnlock()
-	return s.nodes
+	var nodeInfos []*meshtastic.NodeInfo
+	for _, n := range s.nodes {
+		nodeInfos = append(nodeInfos, proto.Clone(n).(*meshtastic.NodeInfo))
+	}
+	return nodeInfos
 }
 
 func (s *State) Channels() []*meshtastic.Channel {
 	s.RLock()
 	defer s.RUnlock()
-	return s.channels
+	var channels []*meshtastic.Channel
+	for _, n := range s.channels {
+		channels = append(channels, proto.Clone(n).(*meshtastic.Channel))
+	}
+	return channels
 }
 
 func (s *State) Configs() []*meshtastic.Config {
 	s.RLock()
 	defer s.RUnlock()
-	return s.configs
+	var configs []*meshtastic.Config
+	for _, n := range s.configs {
+		configs = append(configs, proto.Clone(n).(*meshtastic.Config))
+	}
+	return configs
 }
 
 func (s *State) Modules() []*meshtastic.ModuleConfig {
 	s.RLock()
 	defer s.RUnlock()
-	return s.modules
+	var configs []*meshtastic.ModuleConfig
+	for _, n := range s.modules {
+		configs = append(configs, proto.Clone(n).(*meshtastic.ModuleConfig))
+	}
+	return configs
 }
 
 func (s *State) SetComplete(complete bool) {

--- a/transport/client.go
+++ b/transport/client.go
@@ -136,6 +136,7 @@ func (s *State) AddModule(module *meshtastic.ModuleConfig) {
 
 func NewClient(sc *StreamConn, errorOnNoHandler bool) *Client {
 	return &Client{
+		// TODO: allow consumer to specify logger
 		log:      slog.Default().WithGroup("client"),
 		sc:       sc,
 		handlers: NewHandlerRegistry(errorOnNoHandler),


### PR DESCRIPTION
- now using `log/slog` for logging
- export `Client.Config` values (received upon initial connection to a device) which are now `Client.State`
- add getters and setters to avoid race conditions
- `Client.Connect()` now requires `context.Context` be passed in useful for timeout when connecting to a device
- `Client.Connect()` now hangs until the radio finishes sending it's responses to the `WantConfig`. It will error or timeout if it fails. Once it returns consumers are now free to request all the information from the radio via `Client.State` getters.